### PR TITLE
Add muser branding + chat window

### DIFF
--- a/website/src/pages/embed.astro
+++ b/website/src/pages/embed.astro
@@ -6,7 +6,7 @@ import { Repl } from '../repl/Repl.jsx';
 <html>
   <head>
     <HeadCommon />
-    <title>Strudel REPL</title>
+    <title>muser</title>
   </head>
   <body>
     <Repl client:only="react" embedded />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -6,7 +6,7 @@ import { Repl } from '../repl/Repl';
 <html lang="en" class="m-0 dark">
   <head>
     <HeadCommon />
-    <title>Strudel REPL</title>
+    <title>muser</title>
   </head>
   <body class="h-app-height bg-background m-0">
     <Repl client:only="react" />

--- a/website/src/repl/components/Header.jsx
+++ b/website/src/repl/components/Header.jsx
@@ -47,7 +47,6 @@ export function Header({ context, embedded = false }) {
               }
             }}
           >
-            <span className="block text-foreground rotate-90">꩜</span>
           </div>
           {!isZen && (
             <div className="space-x-2">
@@ -101,7 +100,7 @@ export function Header({ context, embedded = false }) {
               <span> shuffle</span>
             </button>
           ) */}
-          {!isEmbedded && (
+          {/* {!isEmbedded && (
             <button
               title="share"
               className={cx(
@@ -112,8 +111,8 @@ export function Header({ context, embedded = false }) {
             >
               <span>share</span>
             </button>
-          )}
-          {!isEmbedded && (
+          )} */}
+          {/* {!isEmbedded && (
             <a
               title="learn"
               href={`${baseNoTrailing}/workshop/getting-started/`}
@@ -121,7 +120,7 @@ export function Header({ context, embedded = false }) {
             >
               <span>learn</span>
             </a>
-          )}
+          )} */}
           {/* {isEmbedded && (
             <button className={cx('hover:opacity-50 px-2')}>
               <a href={window.location.href} target="_blank" rel="noopener noreferrer" title="Open in REPL">

--- a/website/src/repl/components/chat/ChatWindow.jsx
+++ b/website/src/repl/components/chat/ChatWindow.jsx
@@ -1,0 +1,91 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function ChatWindow() {
+    const [messages, setMessages] = useState([
+        {
+            id: 0,
+            text: "welcome to muser, a new vibe coding music platform to generate music. Chat to get started.",
+            sender: 'bot',
+            timestamp: new Date()
+        }
+    ]);
+    const [inputValue, setInputValue] = useState('');
+    const messagesEndRef = useRef(null);
+
+    const scrollToBottom = () => {
+        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    }, [messages]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!inputValue.trim()) return;
+
+        // Add user message
+        const userMessage = {
+            id: Date.now(),
+            text: inputValue,
+            sender: 'user',
+            timestamp: new Date()
+        };
+
+        // Add placeholder response
+        // FIXME: jae replace this with real LLM call
+        const botMessage = {
+            id: Date.now() + 1,
+            text: "nah im good",
+            sender: 'bot',
+            timestamp: new Date()
+        };
+
+        setMessages(prev => [...prev, userMessage, botMessage]);
+        setInputValue('');
+    };
+
+    return (
+        <div className="mt-6 flex flex-col h-full">
+            {/* Chat Messages */}
+            <div className="flex-1 space-y-4 overflow-y-auto">
+                {messages.map((message) => (
+                    <div
+                        key={message.id}
+                        className={`flex ${message.sender === 'user' ? 'justify-end' : 'justify-start'}`}
+                    >
+                        <div
+                            className={`max-w-xs lg:max-w-md px-4 py-2 rounded-lg ${message.sender === 'user'
+                                ? 'bg-blue-500 text-white'
+                                : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                                }`}
+                        >
+                            <p className="text-sm">{message.text}</p>
+                        </div>
+                    </div>
+                ))}
+                <div ref={messagesEndRef} />
+            </div>
+
+            {/* Chat Input */}
+            <form onSubmit={handleSubmit} className="mt-6 flex-shrink-0">
+                <div className="flex gap-2">
+                    <input
+                        type="text"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        placeholder="Generate lofi beats mixed with a bit of jazz..."
+                        className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <button
+                        type="submit"
+                        className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                        disabled={!inputValue.trim()}
+                    >
+                        Send
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/website/src/repl/components/panel/Panel.jsx
+++ b/website/src/repl/components/panel/Panel.jsx
@@ -9,6 +9,7 @@ import { useLogger } from '../useLogger';
 import { WelcomeTab } from './WelcomeTab';
 import { PatternsTab } from './PatternsTab';
 import { ChevronLeftIcon, XMarkIcon } from '@heroicons/react/16/solid';
+import { WelcomeMuser } from './WelcomeMuser';
 
 const TAURI = typeof window !== 'undefined' && window.__TAURI__;
 
@@ -131,7 +132,8 @@ function PanelContent({ context, tab }) {
     case tabNames.files:
       return <FilesTab />;
     default:
-      return <WelcomeTab context={context} />;
+      // return <WelcomeTab context={context} />;
+      return <WelcomeMuser context={context} />;
   }
 }
 

--- a/website/src/repl/components/panel/WelcomeMuser.jsx
+++ b/website/src/repl/components/panel/WelcomeMuser.jsx
@@ -1,0 +1,17 @@
+import { useSettings } from '@src/settings.mjs';
+
+const { BASE_URL } = import.meta.env;
+const baseNoTrailing = BASE_URL.endsWith('/') ? BASE_URL.slice(0, -1) : BASE_URL;
+
+export function WelcomeMuser({ context }) {
+  const { fontFamily } = useSettings();
+  return (
+    <div className="prose dark:prose-invert min-w-full pt-2 font-sans pb-8 px-4 " style={{ fontFamily }}>
+      <h3>welcome to muser</h3>
+      <p>
+        You have found <span className="underline">muser</span>, a new vibe coding music platform to generate music.
+        Chat to get started.
+      </p>
+    </div>
+  );
+}

--- a/website/src/repl/components/panel/WelcomeMuser.jsx
+++ b/website/src/repl/components/panel/WelcomeMuser.jsx
@@ -1,17 +1,15 @@
 import { useSettings } from '@src/settings.mjs';
+import { ChatWindow } from '@src/repl/components/chat/ChatWindow.jsx';
 
 const { BASE_URL } = import.meta.env;
 const baseNoTrailing = BASE_URL.endsWith('/') ? BASE_URL.slice(0, -1) : BASE_URL;
 
 export function WelcomeMuser({ context }) {
   const { fontFamily } = useSettings();
+
   return (
-    <div className="prose dark:prose-invert min-w-full pt-2 font-sans pb-8 px-4 " style={{ fontFamily }}>
-      <h3>welcome to muser</h3>
-      <p>
-        You have found <span className="underline">muser</span>, a new vibe coding music platform to generate music.
-        Chat to get started.
-      </p>
+    <div className="prose dark:prose-invert min-w-full pt-2 font-sans pb-8 px-4 h-full" style={{ fontFamily }}>
+      <ChatWindow />
     </div>
   );
 }


### PR DESCRIPTION
## Summary by Sourcery

Rebrand the REPL to “muser” and introduce a chat-driven welcome interface by adding a ChatWindow component and embedding it in a new WelcomeMuser panel.

New Features:
- Add ChatWindow component to provide chat-based user interaction
- Add WelcomeMuser panel that embeds the chat window as the default welcome screen

Enhancements:
- Rebrand application from “Strudel REPL” to “muser” by updating page titles and header logo
- Replace default WelcomeTab with WelcomeMuser in the main panel content
- Remove legacy share and learn buttons from the header