### PR TITLE
add genai

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,9 @@ importers:
       '@docsearch/react':
         specifier: ^3.8.3
         version: 3.8.3(@algolia/client-search@5.20.0)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.13.0)
+      '@google/genai':
+        specifier: ^1.8.0
+        version: 1.8.0(encoding@0.1.13)
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1760,6 +1763,15 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@google/genai@1.8.0':
+    resolution: {integrity: sha512-n3KiMFesQCy2R9iSdBIuJ0JWYQ1HZBJJkmt4PPZMGZKvlgHhBAGw1kUMyX+vsAIzprN3lK45DI755lm70wPOOg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.11.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@headlessui/react@2.2.0':
     resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
@@ -3209,6 +3221,9 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
+  bignumber.js@9.3.0:
+    resolution: {integrity: sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==}
+
   bin-links@4.0.4:
     resolution: {integrity: sha512-cMtq4W5ZsEwcutJrVId+a/tjt8GSbS+h0oNkdl6+6rBuEv8Ot33Bevj5KPm40t309zuhVic8NjpuL42QCiJWWA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3247,6 +3262,9 @@ packages:
 
   buffer-alloc@1.2.0:
     resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
@@ -3858,6 +3876,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -4325,6 +4346,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -4450,6 +4479,10 @@ packages:
     engines: {node: '>=0.6.0'}
     hasBin: true
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
   google-closure-compiler-java@20221102.0.1:
     resolution: {integrity: sha512-rMKLEma3uSe/6MGHtivDezTv4u5iaDEyxoy9No+1WruPSZ5h1gBZLONcfCA8JaoGojFPdHZI1qbwT0EveEWnAg==}
 
@@ -4476,12 +4509,20 @@ packages:
   google-closure-library@20221102.0.0:
     resolution: {integrity: sha512-M5+LWPS99tMB9dOGpZjLT9CdIYpnwBZiwB+dCmZFOOvwJiOWytntzJ/a/hoNF6zxD15l3GWwRJiEkL636D6DRQ==}
 
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   h3@1.14.0:
     resolution: {integrity: sha512-ao22eiONdgelqcnknw0iD645qW0s9NnrJHr5OBz4WOMdBdycfSas1EQf1wXRsm+PcB2Yoj43pjBPwqIpJQTeWg==}
@@ -5034,6 +5075,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -5093,6 +5137,12 @@ packages:
 
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   jzz@1.8.8:
     resolution: {integrity: sha512-Oupj8xbUtJbP6s1KJWr1ZiGgU1JlUocetHqwVyGKuPhXjvPWOj5+SCirEr/OIVUXsG3iz04Unlu8uUm5EhtIDA==}
@@ -5714,6 +5764,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
@@ -7413,6 +7464,10 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -7657,6 +7712,7 @@ packages:
 
   workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@7.0.0:
     resolution: {integrity: sha512-juWCSrxo/fiMz3RsvDspeSLGmbgC0U9tKqcUPZBCf35s64wlaLXyn2KdHHXVQrb2cqF7I0Hc9siQalainmnXJA==}
@@ -8974,6 +9030,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@google/genai@1.8.0(encoding@0.1.13)':
+    dependencies:
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      ws: 8.18.0
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@headlessui/react@2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9509,7 +9577,7 @@ snapshots:
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       is-plain-object: 5.0.0
-      node-fetch: 2.6.7(encoding@0.1.13)
+      node-fetch: 2.7.0(encoding@0.1.13)
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
@@ -10799,6 +10867,8 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
+  bignumber.js@9.3.0: {}
+
   bin-links@4.0.4:
     dependencies:
       cmd-shim: 6.0.3
@@ -10853,6 +10923,8 @@ snapshots:
     dependencies:
       buffer-alloc-unsafe: 1.1.0
       buffer-fill: 1.0.0
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-fill@1.0.0: {}
 
@@ -11430,6 +11502,10 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ejs@3.1.10:
     dependencies:
@@ -12013,6 +12089,26 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@6.7.1(encoding@0.1.13):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1(encoding@0.1.13):
+    dependencies:
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   get-amd-module-type@6.0.0:
@@ -12155,6 +12251,18 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  google-auth-library@9.15.1(encoding@0.1.13):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   google-closure-compiler-java@20221102.0.1: {}
 
   google-closure-compiler-linux@20221102.0.1:
@@ -12180,9 +12288,19 @@ snapshots:
 
   google-closure-library@20221102.0.0: {}
 
+  google-logging-utils@0.0.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0(encoding@0.1.13):
+    dependencies:
+      gaxios: 6.7.1(encoding@0.1.13)
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   h3@1.14.0:
     dependencies:
@@ -12830,6 +12948,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.0
+
   json-buffer@3.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -12871,6 +12993,17 @@ snapshots:
   just-diff-apply@5.5.0: {}
 
   just-diff@6.0.2: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   jzz@1.8.8:
     dependencies:
@@ -15826,6 +15959,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@9.0.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
     "@astrojs/tailwind": "^5.1.5",
     "@docsearch/css": "^3.8.3",
     "@docsearch/react": "^3.8.3",
+    "@google/genai": "^1.8.0",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "@nanostores/persistent": "^0.10.2",
@@ -33,6 +34,7 @@
     "@strudel/hydra": "workspace:*",
     "@strudel/midi": "workspace:*",
     "@strudel/mini": "workspace:*",
+    "@strudel/mondo": "workspace:*",
     "@strudel/motion": "workspace:*",
     "@strudel/mqtt": "workspace:*",
     "@strudel/osc": "workspace:*",
@@ -42,7 +44,6 @@
     "@strudel/tonal": "workspace:*",
     "@strudel/transpiler": "workspace:*",
     "@strudel/webaudio": "workspace:*",
-    "@strudel/mondo": "workspace:*",
     "@strudel/xen": "workspace:*",
     "@supabase/supabase-js": "^2.48.1",
     "@tailwindcss/forms": "^0.5.10",
@@ -74,7 +75,7 @@
     "@vite-pwa/astro": "^0.5.0",
     "html-escaper": "^3.0.3",
     "sharp": "^0.33.5",
-    "workbox-window": "^7.3.0",
-    "vite-plugin-bundle-audioworklet": "workspace:*"
+    "vite-plugin-bundle-audioworklet": "workspace:*",
+    "workbox-window": "^7.3.0"
   }
 }

--- a/website/src/repl/components/Backend.jsx
+++ b/website/src/repl/components/Backend.jsx
@@ -1,0 +1,40 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import ModifiedDocs from './ModifiedDocs.mdx?raw';
+const ai = new GoogleGenAI({
+    apiKey: "",
+});
+
+export async function callAI(messages) {
+    const response = await ai.models.generateContent({
+        model: "gemini-2.5-flash",
+        contents: [
+            {
+                role: "system",
+                parts: [{ text: ModifiedDocs }]
+            },
+            {
+                role: "user",
+                parts: [{ text: "generate a lofi beat" }]
+            }
+        ],
+        config: {
+            responseMimeType: "application/json",
+            responseSchema: {
+                type: Type.OBJECT,
+                properties: {
+                    code: {
+                        type: Type.STRING,
+                        description: "The Strudel code to generate the requested music pattern"
+                    },
+                    reasoning: {
+                        type: Type.STRING,
+                        description: "Explanation of the musical choices and pattern design decisions"
+                    }
+                },
+                propertyOrdering: ["code", "reasoning"]
+            }
+        },
+    });
+    return response.text;
+    // console.log(response.text);
+}

--- a/website/src/repl/components/ModifiedDocs.mdx
+++ b/website/src/repl/components/ModifiedDocs.mdx
@@ -1,0 +1,87 @@
+You are a specialized code generation agent for Strudel, a JavaScript-based live coding environment for algorithmic music composition. Generate music based on user's request. Below is strudel docs
+
+## Core Concepts
+
+**Pattern-Based Programming**: Everything in Strudel is a pattern - sequences of values that can be transformed, combined, and manipulated over time. Patterns are pure functions that generate events when queried by the scheduler.
+
+**Mini-Notation**: A concise DSL for expressing rhythmic patterns using strings like `"bd sd hh"` or `"c3 e3 g3"`. Supports brackets `[x y]` for polyrhythms, multiplication `*n` for repetition, and Euclidean rhythms `(pulses,steps,offset)`.
+
+**Function Chaining**: Use dot notation to chain transformations: `note("c e g").s("piano").cutoff(500).delay(0.5)`
+
+## Key Functions and Syntax
+
+### Pattern Creation
+- `note("c3 e3 g3")` - Create note patterns
+- `s("bd sd hh")` - Create sample patterns  
+- `freq("220 440 880")` - Create frequency patterns
+- `stack(p1, p2, p3)` - Layer patterns vertically
+- `cat(p1, p2, p3)` - Sequence patterns horizontally
+
+### Common Transformations
+- `.s("sound")` - Set sound/sample
+- `.scale("C major")` - Apply musical scale
+- `.off(offset, transform)` - Layer with offset
+- `.superimpose(transform)` - Add transformed layer
+- `.fast(n)` / `.slow(n)` - Change tempo
+- `.every(n, transform)` - Apply transform every n cycles
+- `.sometimes(transform)` - Randomly apply transform
+- `.legato(n)` - Extend note durations
+- `.echo(repeats, delay, decay)` - Add echoes
+
+### Sound Design
+- `.cutoff(freq)` - Low-pass filter
+- `.gain(level)` - Volume control
+- `.delay(wet)` - Add delay effect
+- `.room(reverb)` - Add reverb
+- `.attack(time)` / `.decay(time)` - Envelope controls
+
+### Advanced Patterns
+- Euclidean rhythms: `"(3,8,0)"` for 3 pulses in 8 steps
+- Polyrhythms: `"[bd sd] hh"` for nested patterns
+- Randomization: `sometimes()`, `degradeBy(amount)`
+- Algorithmic: `perlin.range(min,max)`, `sine.slow(n)`
+
+## Musical Guidelines
+
+1. **Start Simple**: Begin with basic patterns like `s("bd sd hh")` or `note("c e g")`
+2. **Build Complexity**: Layer patterns with `stack()` and transform with `.off()`
+3. **Use Musical Scales**: Apply scales like `"C major"`, `"D minor"`, `"pentatonic"`
+4. **Rhythmic Variation**: Use Euclidean rhythms and polyrhythms for interest
+5. **Sound Design**: Combine samples with synths, add effects gradually
+6. **Live Coding Style**: Write patterns that can be modified in real-time
+
+## Common Patterns
+
+**Basic Drum Beat**: `s("bd sd hh")`
+**Euclidean Rhythm**: `s("bd(3,8) sd(2,8) hh(5,8)")`
+**Melodic Pattern**: `note("c3 e3 g3").s("piano").scale("C major")`
+**Complex Layering**: 
+```javascript
+stack(
+  s("bd sd hh").sometimes(ply(2)),
+  note("c3 e3 g3").s("sawtooth").cutoff(500),
+  note("a2 e2").s("triangle").gain(0.3)
+)
+```
+
+## Best Practices
+
+1. **Use meaningful variable names** for complex patterns
+2. **Comment your code** with `//` for clarity
+3. **Start with short patterns** and build up complexity
+4. **Experiment with transformations** - try `.every()`, `.sometimes()`, `.off()`
+5. **Balance layers** with appropriate `.gain()` values
+6. **Use musical scales** for melodic content
+7. **Incorporate randomness** for generative feel
+8. **Consider performance** - avoid overly complex patterns that may cause audio glitches
+
+## Response Format
+
+When generating Strudel code:
+1. Provide a complete, runnable pattern
+2. Include comments explaining key transformations
+3. Suggest variations or modifications
+4. Consider musical context and genre appropriateness
+5. Ensure patterns are suitable for live coding (modifiable in real-time)
+
+Remember that Strudel is designed for live coding - patterns should be expressive, musical, and easily modifiable during performance.


### PR DESCRIPTION
## Summary by Sourcery

Integrate Google GenAI into the website’s REPL by adding the @google/genai dependency, expanding the lockfile with related packages, providing Strudel live-coding documentation, and implementing a backend component to invoke the GenAI API.

New Features:
- Integrate Google GenAI into the REPL by adding the @google/genai package and its lockfile entries
- Add a backend component to call the GoogleGenAI API for generating Strudel music patterns
- Introduce a new MDX document containing Strudel live-coding documentation for AI system prompts

Enhancements:
- Update node-fetch to v2.7.0
- Reorder and update website dependencies in package.json

Documentation:
- Add `ModifiedDocs.mdx` with core Strudel patterns guide for AI usage