### PR TITLE
add top charts tab

### DIFF
--- a/website/src/repl/components/panel/Panel.jsx
+++ b/website/src/repl/components/panel/Panel.jsx
@@ -10,6 +10,7 @@ import { WelcomeTab } from './WelcomeTab';
 import { PatternsTab } from './PatternsTab';
 import { ChevronLeftIcon, XMarkIcon } from '@heroicons/react/16/solid';
 import { WelcomeMuser } from './WelcomeMuser';
+import { TopChartsTab } from './TopChartsTab';
 
 const TAURI = typeof window !== 'undefined' && window.__TAURI__;
 
@@ -83,6 +84,7 @@ const tabNames = {
   reference: 'reference',
   console: 'console',
   settings: 'settings',
+  topCharts: 'top charts',
 };
 if (TAURI) {
   tabNames.files = 'files';
@@ -131,6 +133,8 @@ function PanelContent({ context, tab }) {
       return <SettingsTab started={context.started} />;
     case tabNames.files:
       return <FilesTab />;
+    case tabNames.topCharts:
+      return <TopChartsTab context={context} />;
     default:
       // return <WelcomeTab context={context} />;
       return <WelcomeMuser context={context} />;

--- a/website/src/repl/components/panel/TopChartsTab.jsx
+++ b/website/src/repl/components/panel/TopChartsTab.jsx
@@ -1,0 +1,45 @@
+import { useSettings } from '@src/settings.mjs';
+import { ch } from '@strudel/core';
+import { useState } from 'react';
+
+const { BASE_URL } = import.meta.env;
+
+const ChartResult = ({ name, artist, link, index }) => {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">{index + 1}.</span>
+      <div className="flex flex-row">
+        <a href={link} target="_blank" rel="noopener noreferrer" className="hover:underline">{name} by {artist}</a>
+      </div>
+    </div>
+  )
+}
+
+const sampleCharts = [
+  {
+    name: 'die for you',
+    artist: 'weeknd',
+    link: 'https://www.billboard.com/charts/hot-100/'
+  },
+  {
+    name: 'save your tears',
+    artist: 'weeknd',
+    link: 'https://www.billboard.com/charts/hot-100/'
+  }
+]
+
+export function TopChartsTab({ context }) {
+  const { fontFamily } = useSettings();
+  const [chartResults, setChartResults] = useState(sampleCharts);
+
+  return (
+    <div className="prose dark:prose-invert min-w-full pt-2 font-sans pb-8 px-4 h-full" style={{ fontFamily }}>
+      <h3>top charts</h3>
+      <div className="flex flex-col gap-2">
+        {chartResults.map((chart, index) => (
+          <ChartResult key={chart.name} {...chart} index={index} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a new "Top Charts" tab to the REPL panel, providing a component that displays a list of sample music chart entries.

New Features:
- Introduce TopChartsTab component to render top chart listings with sample data
- Add "top charts" to the panel tab names and switch logic to display the new tab